### PR TITLE
Bugfix: enable custom timeouts

### DIFF
--- a/src/main/java/com/prime157/citrus/aws/sqs/KinesisConsumer.java
+++ b/src/main/java/com/prime157/citrus/aws/sqs/KinesisConsumer.java
@@ -57,7 +57,7 @@ public class KinesisConsumer implements Consumer {
         while (messages.isEmpty()) {
             pollMessages();
             final long duration = System.currentTimeMillis() - started;
-            if (duration > endpointConfiguration.getTimeout()) {
+            if (duration > timeout) {
                 LOGGER.warn("Failed to receive message on time");
                 break;
             }


### PR DESCRIPTION
Hi Dimo, greetings from ConSol! 😊

I made a small bugfix to enable custom timeouts for a Kinesis consumer, so something like this can be used:
```java
action -> action.endpoint(kinesisEndpoint).payload(expectedData).timeout(customTimeout)
```
Currently these custom timeouts will be ignored and always the configured timeouts from KinesisEndpointConfiguration will be used.

Best regards!